### PR TITLE
Remove potential PII from error logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # [v13.2.3](https://github.com/purecloudlabs/genesys-cloud-streaming-client/compare/v13.2.2...v13.2.3)
 ### Fixed
 * [PCM-1572](https://inindca.atlassian.net/browse/PCM-1572) – changed http request to `subscriptions` to not retry on failures.
+* Removed PII logging from failed HTTP requests
 
 # [v13.2.2](https://github.com/purecloudlabs/genesys-cloud-streaming-client/compare/v13.2.1...v13.2.2)
 ### Fixed

--- a/src/http-client.ts
+++ b/src/http-client.ts
@@ -91,13 +91,14 @@ export class HttpClient {
         status: error.status,
 
         correlationId: res.headers['inin-correlation-id'],
-        responseBody: res.text,
+        // Potentially could contain PII
+        // responseBody: res.text,
+        // requestBody: res.req._data,
+        // url: res.error.url,
+        message: 'Error making HTTP request', // res.error.message,
 
         method: res.req.method,
-        requestBody: res.req._data,
 
-        url: res.error.url,
-        message: res.error.message,
         name: res.error.name,
         stack: res.error.stack
       };

--- a/src/request-logger.ts
+++ b/src/request-logger.ts
@@ -4,7 +4,7 @@ export default function attachSuperagentLogger (logger, data, req) {
   let method = req.method;
   logger = logger || console;
 
-  logger.debug(`request: ${method.toUpperCase()} ${req.url}`, { timestamp, data });
+  logger.debug(`request: ${method.toUpperCase()} ${req.url}`, { timestamp, data }, true);
 
   req.on('response', function (res) {
     let now = new Date().getTime();
@@ -13,12 +13,12 @@ export default function attachSuperagentLogger (logger, data, req) {
     let correlationId = res.headers['inin-correlation-id'];
     let body = JSON.stringify(res.body);
 
-    logger.debug(`response: ${method.toUpperCase()} ${req.url}`,
-      { now,
-        status,
-        elapsed,
-        correlationId,
-        body
-      });
+    logger.debug(`response: ${method.toUpperCase()} ${req.url}`, {
+      now,
+      status,
+      elapsed,
+      correlationId,
+      body
+    }, true);
   });
 }

--- a/test/unit/http-client.test.ts
+++ b/test/unit/http-client.test.ts
@@ -190,13 +190,13 @@ describe('HttpRequestClient', () => {
         status: origError.status,
 
         correlationId: res.headers['inin-correlation-id'],
-        responseBody: res.text,
+        // responseBody: res.text,
 
         method: res.req.method,
-        requestBody: res.req._data,
+        // requestBody: res.req._data,
 
-        url: res.error.url,
-        message: res.error.message,
+        // url: res.error.url,
+        message: 'Error making HTTP request', //res.error.message,
         name: res.error.name,
         stack: res.error.stack
       });


### PR DESCRIPTION
remove url, responseBody, requestBody, and error message from failed http request as these may contain PII