### PR TITLE
[PCM-1624] - Added error logging for failed HTTP requests to console - not sending to sumo.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 * fixed unit tests in later versions of node
 ### Added
+* [PCM-1624](https://inindca.atlassian.net/browse/PCM-1624) - Added logging for failed HTTP requests to console - not sending to Sumo.
 * added more logging around webrtc signaling
 
 # [v13.2.5](https://github.com/purecloudlabs/genesys-cloud-streaming-client/compare/v13.2.4...v13.2.5)

--- a/src/http-client.ts
+++ b/src/http-client.ts
@@ -39,7 +39,6 @@ export class HttpClient {
   }
 
   async requestApi (path: string, opts: RequestApiOptions): Promise<any> {
-    console.error(opts.logger);
     let response = request[opts.method](this._buildUri(opts.host, path, opts.version))
       .use(reqlogger.bind(this, opts.logger, opts.data))
       .type(opts.contentType || 'json');

--- a/src/http-client.ts
+++ b/src/http-client.ts
@@ -58,7 +58,6 @@ export class HttpClient {
         status: err.status,
         correlationId: res.headers['inin-correlation-id'],
         responseBody: res.text,
-        requestBody: res.req._data,
         url: res.error.url,
         message: res.error.message,
         method: res.req.method,

--- a/src/http-client.ts
+++ b/src/http-client.ts
@@ -51,22 +51,9 @@ export class HttpClient {
     try {
       return await response.send(opts.data); // trigger request
     } catch (err) {
-      const res = err.response;
-
-      // Potentially contains PII information - Do not send to Sumo, just log to console.
-      throw {
-        status: err.status,
-        correlationId: res.headers['inin-correlation-id'],
-        responseBody: res.text,
-        url: res.error.url,
-        message: res.error.message,
-        method: res.req.method,
-        name: res.error.name,
-        stack: res.error.stack
-      };
+      throw err;
     }
   }
-
   stopAllRetries (): void {
     Array.from(this._httpRetryingRequests.keys())
       .forEach(key => this.cancelRetryRequest(key));

--- a/src/http-client.ts
+++ b/src/http-client.ts
@@ -65,7 +65,7 @@ export class HttpClient {
         method: res.req.method,
         name: res.error.name,
         stack: res.error.stack
-      }
+      };
     }
   }
 

--- a/test/unit/http-client.test.ts
+++ b/test/unit/http-client.test.ts
@@ -71,7 +71,6 @@ describe('HttpRequestClient', () => {
         await http.requestApi(path, { host, method: 'get' });
         fail('should have thrown');
       } catch (error) {
-        console.log(error.body);
         expect(error.response.body.message).toBe('bad request');
         expect(users.isDone()).toBe(true);
       }

--- a/test/unit/http-client.test.ts
+++ b/test/unit/http-client.test.ts
@@ -71,7 +71,8 @@ describe('HttpRequestClient', () => {
         await http.requestApi(path, { host, method: 'get' });
         fail('should have thrown');
       } catch (error) {
-        expect(error.correlationId).toBe('abc123');
+        console.log(error.body);
+        expect(error.response.body.message).toBe('bad request');
         expect(users.isDone()).toBe(true);
       }
     });


### PR DESCRIPTION
- We already aren't sending these HTTP failures to Sumo. Its possible they'll contain PII so instead we'll just throw an error and log them to the console. 
- Removed _sanitized_ error from streaming-client.
- Still exposing `formatRequestError` so that consuming applications can clean up errors before sending to Sumo.
