### PR TITLE
PCM-1844 stop sending logs on disconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 * [PCM-1837](https://inindca.atlassian.net/browse/PCM-1837) – add `setAccessToken(token)` function
+* [PCM-1844](https://inindca.atlassian.net/browse/PCM-1844) – stop sending logs on disconnect:
+  * add `stopServerLogging()` & `startServerLogging()` functions to allow consumers to stop sending server
+    logs that are sent via the client-logger.
+  * on `client.disconnect()`, logs will stop being sent to the server.
+  * on `client.connect()`, logs will start being sent to the server again.
 
 ### Changed
 * [PCM-1842](https://inindca.atlassian.net/browse/PCM-1842) – migrate to the new pipeline. Also versioning cdn urls with major and exact versions. For example:

--- a/src/client.ts
+++ b/src/client.ts
@@ -289,6 +289,7 @@ export class Client {
 
   disconnect () {
     this.logger.info('streamingClient.disconnect was called');
+    this.stopServerLogging();
     return timeoutPromise(resolve => {
       this._stanzaio.once('disconnected', resolve);
       this.autoReconnect = false;
@@ -309,8 +310,10 @@ export class Client {
   }
 
   connect () {
+    this.startServerLogging();
     this.logger.info('streamingClient.connect was called');
     this.connecting = true;
+
     if (this.config.jwt) {
       return timeoutPromise(resolve => {
         this.once('connected', resolve);
@@ -364,6 +367,17 @@ export class Client {
         return Promise.reject(err);
       });
 
+  }
+
+  stopServerLogging () {
+    /* flush all pending logs and webrtc stats – then turn off the logger */
+    this.logger.sendAllLogsInstantly();
+    this.logger.stopServerLogging();
+    this._webrtcSessions.flushStats();
+  }
+
+  startServerLogging () {
+    this.logger.startServerLogging();
   }
 
   setAccessToken (token: string): void {

--- a/src/webrtc.ts
+++ b/src/webrtc.ts
@@ -147,6 +147,11 @@ export class WebrtcExtension extends EventEmitter {
   // This should be moved when the sdk is the primary consumer
   proxyStatsForSession (session: GenesysCloudMediaSession) {
     session.on('stats', (statsEvent: StatsEvent) => {
+      /* if our logger was stopped, we need to stop stats logging too */
+      if (this.client.logger['stopReason']) {
+        return;
+      }
+
       const statsCopy = JSON.parse(JSON.stringify(statsEvent));
       const extraDetails = {
         conference: (session as any).conversationId,
@@ -167,7 +172,7 @@ export class WebrtcExtension extends EventEmitter {
 
       // If it exceeds max size, don't append just send current payload.
       if (exceedsMaxStatSize) {
-        this.throttledSendStats.flush();
+        this.flushStats();
       } else {
         this.throttledSendStats();
       }
@@ -186,6 +191,10 @@ export class WebrtcExtension extends EventEmitter {
     }
 
     return logDetails;
+  }
+
+  flushStats () {
+    this.throttledSendStats.flush();
   }
 
   async sendStats () {

--- a/test/unit/client.test.ts
+++ b/test/unit/client.test.ts
@@ -17,7 +17,9 @@ const defaultOptions = {
     debug () { },
     info () { },
     log () { },
-  }
+  },
+  startServerLogging: jest.fn(),
+  stopServerLogging: jest.fn()
 };
 Object.freeze(defaultOptions);
 

--- a/test/unit/webrtc.test.ts
+++ b/test/unit/webrtc.test.ts
@@ -85,7 +85,7 @@ describe('prepareSession', () => {
     webrtc.pendingSessions = { mysid: { sessionId: 'mysid' } as any };
 
     expect(Object.values(webrtc.pendingSessions).length).toBe(1);
-    const session = webrtc.prepareSession({sid: 'mysid'} as any);
+    const session = webrtc.prepareSession({ sid: 'mysid' } as any);
     expect(Object.values(webrtc.pendingSessions).length).toBe(0);
   });
 
@@ -98,8 +98,8 @@ describe('prepareSession', () => {
     webrtc.pendingSessions = { mysid: { sessionId: 'mysid', sessionType: 'softphone' } as any };
 
     expect(Object.values(webrtc.pendingSessions).length).toBe(1);
-    const session = webrtc.prepareSession({sid: 'mysid'} as any);
-    expect((GenesysCloudMediaSession as jest.Mock)).toHaveBeenCalledWith(expect.objectContaining({sessionType: 'softphone'}));
+    const session = webrtc.prepareSession({ sid: 'mysid' } as any);
+    expect((GenesysCloudMediaSession as jest.Mock)).toHaveBeenCalledWith(expect.objectContaining({ sessionType: 'softphone' }));
     expect(Object.values(webrtc.pendingSessions).length).toBe(0);
   });
 
@@ -1042,6 +1042,10 @@ describe('getSessionTypeByJid', () => {
 });
 
 describe('proxyStatsForSession', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
   it('should call throttledSendStats', () => {
     const client = new Client({});
     const webrtc = new WebrtcExtension(client as any, {} as any);
@@ -1106,7 +1110,22 @@ describe('proxyStatsForSession', () => {
     expect(webrtc['throttledSendStats'].flush).toHaveBeenCalled();
   });
 
+  it('should not proxy stats if the logger has stopped', () => {
+    const client = new Client({});
+    const webrtc = new WebrtcExtension(client as any, {} as any);
+    const session: any = new EventEmitter();
 
+    const spy = jest.spyOn(statsFormatter, 'formatStatsEvent');
+
+    webrtc.proxyStatsForSession(session);
+    client.logger['stopReason'] = '401';
+
+    session.emit('stats', {
+      actionName: 'test'
+    });
+
+    expect(spy).not.toHaveBeenCalled();
+  });
 });
 
 describe('sendStats', () => {


### PR DESCRIPTION
This is hopefully going to help issues like this: https://inindca.atlassian.net/browse/PCM-1835

This will warrant a minor version bump. Does anyone see any potentially issues with stopping the logs on disconnect? We do flush all stats/logs before we stop. Not sure how this will affect stats if the streaming-client disconnects but the rtc session is still ongoing. 