### PR TITLE
Remove topic on last handler unsubscribe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 # [Unreleased](https://github.com/purecloudlabs/genesys-cloud-streaming-client/compare/v13.4.1...HEAD)
 
+### Changed
+* [PCM-1862](https://inindca.atlassian.net/browse/PCM-1862) - remove topics from the tracked lists (subscriptions, bulkSubscriptions) after their last handlers have been removed
+
 ### Added
 * [PCM-1837](https://inindca.atlassian.net/browse/PCM-1837) – add `setAccessToken(token)` function
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genesys-cloud-streaming-client",
-  "version": "13.5.0",
+  "version": "13.5.1",
   "description": "client for the Genesys Cloud Streaming APIs (websocket/xmpp interface)",
   "repository": "https:github.com/purecloudlabs/genesys-cloud-streaming-client",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genesys-cloud-streaming-client",
-  "version": "13.5.1",
+  "version": "13.5.0",
   "description": "client for the Genesys Cloud Streaming APIs (websocket/xmpp interface)",
   "repository": "https:github.com/purecloudlabs/genesys-cloud-streaming-client",
   "license": "MIT",

--- a/src/notifications.ts
+++ b/src/notifications.ts
@@ -210,6 +210,10 @@ export class Notifications {
       if (handlerIndex > -1) {
         handlers.splice(handlerIndex, 1);
       }
+      if (!handlers.length) {
+        this.subscriptions[t] = [];
+        delete this.bulkSubscriptions[t];
+      }
     });
   }
 

--- a/test/unit/notifications.test.ts
+++ b/test/unit/notifications.test.ts
@@ -163,9 +163,6 @@ describe('Notifications', () => {
     // unsubscribing with an unused handler won't trigger any unsubscribe
     expect(notification.client._stanzaio.unsubscribeFromNode).not.toHaveBeenCalled();
 
-    // unsubscribing with an unused handler won't trigger any unsubscribe
-    expect(notification.client._stanzaio.unsubscribeFromNode).not.toHaveBeenCalled();
-
     // unsubscribing the last handler will unsubscribe the topic
     client.connected = false;
 

--- a/test/unit/notifications.test.ts
+++ b/test/unit/notifications.test.ts
@@ -140,6 +140,7 @@ describe('Notifications', () => {
     // didn't subscribe via xmpp any more (was once previously)
     expect(notification.client._stanzaio.subscribeToNode).toHaveBeenCalledTimes(1);
     apiRequest.done();
+    expect(notification.bulkSubscriptions['topic.three']).toBe(true);
 
     const apiRequest2 = nock('https://api.example.com')
       .put('/api/v2/notifications/channels/notification-test-channel/subscriptions', () => true)
@@ -159,6 +160,8 @@ describe('Notifications', () => {
     expect(notification.client._stanzaio.unsubscribeFromNode).not.toHaveBeenCalled();
 
     await notification.expose.unsubscribe('topic.test', () => { }, true);
+    // unsubscribing with an unused handler won't trigger any unsubscribe
+    expect(notification.client._stanzaio.unsubscribeFromNode).not.toHaveBeenCalled();
 
     // unsubscribing with an unused handler won't trigger any unsubscribe
     expect(notification.client._stanzaio.unsubscribeFromNode).not.toHaveBeenCalled();


### PR DESCRIPTION
We're encountering a case where our client subscribes to many topics (note that handlers are passed)

```
# call to subscribe ~50 topics at a time, letting streaming client update subscriptions after a reasonable debounce
connection.notifications.subscribe(topic, handler, false, priority).then(...);
```

Later when we're done, the same is done in reverse for `unsubscribe`

```
# call to unsubscribe most of the same topics
connection.notifications.unsubscribe(topic, handler)
```

### Problem
Shortly after unsubscribing the relevant topics, we observed a resubscription to those same topics. Internally the issue is that the set of `subscriptions` and `bulkSubscriptions` remains unchanged upon unsubscribe, which in turn causes a subsequent resubscribe call to think those topics are still required

### Solution
When there are no handlers for a given topic, remove them from the tracked list(s) of subscriptions.

Let me know if I'm off somewhere. I've already run this locally and it's corrected our use case but it's entirely possible that another of your consumers will be affected.

