### PR TITLE
PCM-1862 corrected unsubscribe not removing topic from internal tracked lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [PCM-1842](https://inindca.atlassian.net/browse/PCM-1842) – migrate to the new pipeline. Also versioning cdn urls with major and exact versions. For example:
     * `/v13.5.0/streaming-client.browser.js` (exact version)
     * `/v13/streaming-client.browser.js` (locked to latest for a specific major version)
+* [PCM-1862](https://inindca.atlassian.net/browse/PCM-1862) - remove individual topics from the tracked lists (subscriptions) after their last handlers have been removed.
+    Fixed `_notifications.resubscribe()` to not treat individual topics as bulk topics
 ### Fixed
 * Addressed snyk and npm audit issues
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,18 +60,6 @@ webappPipeline {
         ]
     }
 
-    cmConfig = {
-        return [
-            managerEmail: 'genesyscloud-client-media@genesys.com',
-            rollbackPlan: 'Patch version with fix',
-
-            // TODO: kick off a prepublish build of web-directory and link to tests run
-            // against that feature build
-            testResults: 'https://jenkins.ininica.com/job/spigot-tests-streaming-client-test/',
-            qaId: '5d41d9195ca9700dac0ef53a'
-        ]
-    }
-
     deployConfig = [
       dev : 'always',
       test : 'always',

--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@
     // loadScript('test/scripts/custom-logger.js');
     // loadScript('test/scripts/429s.js');
     // loadScript('test/scripts/throttling-ping.js');
+    // loadScript('test/scripts/unsub.js');
   </script>
 
 </body>

--- a/test/scripts/unsub.js
+++ b/test/scripts/unsub.js
@@ -1,0 +1,49 @@
+const client = new window.GenesysCloudStreamingClient(window.scConfig);
+window.client = client;
+
+function logDebug () {
+  console.log('___current subs:', {
+    indiviualSubs: { ...client._notifications.subscriptions },
+    bulkSubs: { ...client._notifications.bulkSubscriptions },
+  })
+}
+
+async function run () {
+  await client.connect();
+
+  const user = await client.http.requestApiWithRetry('users/me', {
+    method: 'get',
+    host: client.config.apiHost,
+    authToken: client.config.authToken,
+    logger: client.logger
+  }).promise.then(res => res.body);
+
+  console.clear();
+
+  const stationTopic = `v2.users.${user.id}.station`;
+  const conversationsTopic = `v2.users.${user.id}.conversations`;
+  const presenceTopic = `v2.users.${user.id}.presence`;
+  const myHandler = () => { /* nothing */ };
+
+  console.log('subscribing to individual station, conversation, & presence topics');
+  await Promise.all([
+    client.notifications.subscribe(stationTopic, myHandler, false),
+    client.notifications.subscribe(presenceTopic, myHandler, false),
+    client.notifications.subscribe(conversationsTopic, myHandler, false)
+  ]);
+  /* here, individual sub list should have three topics with handlers */
+  logDebug();
+
+  console.log('subscribing to bulk station & conversation topics');
+  await client.notifications.bulkSubscribe([stationTopic, conversationsTopic]);
+  /* here, bulk sub list should have two topics with value of `true` */
+  logDebug();
+
+  console.log('unsubscribing from individual station and presence topic');
+  await client.notifications.unsubscribe(stationTopic, myHandler);
+  await client.notifications.unsubscribe(presenceTopic, myHandler);
+  /* here, bulk sub list should have two topics with value of `true` but those topics should not be in the individual list */
+  logDebug();
+}
+
+run();


### PR DESCRIPTION
@shanebruggeman discovered a bug when unsubscribing individual topics. He opened #147, but it needed a little tweaking. It was easier to open a new PR rather than trying to explain what needed to change in the other one. Once this merges, the other should be good to be declined. 

## Problem
Here is the high level that I'm seeing:

``` ts
const myTopic = `v2.users.${id}.conversations`;
const myHandler = (...args) => { /* do stuff */ };

/* subscribe */
await streamingClient.notifications.subscribe(myTopic, myHandler, false);

/* later, we unsubscribe */
await streamingClient.notifications.unsubscribe(myTopic, myHandler, false);
```

Even after this, our streaming-client is still subscribed to the topic (but our handler is no longer wired up).

## Reason

Adding a single subscription using `.subscribe()` will add a listener to `this.subscriptions = [handler]`.

Whereas, `.bulkSubscribe()` will _not_ add listeners but just add `this.bulkSubscriptions[topic] = true`.

## Root Causes
### Problem 1
The issue stems from `resubscribe()`. When calling `subscribe(topic, handler, false /* immediate */)`,
the streaming-client will add `this.subscriptions = [handler]` _but then_ [will debounce](https://github.com/purecloudlabs/genesys-cloud-streaming-client/blob/develop/src/notifications.ts#L308-L310) and [merge _all_ bulk subs and individual subs](https://github.com/purecloudlabs/genesys-cloud-streaming-client/blob/develop/src/notifications.ts#L243-L249) and eventually pass that to `bulkSubscribe()` with `replace: true`.

`bulkSubscribe()` treats all passed in topics as bulk subs and if `replace == true`, it will keep our current individual topics subscriptions too.
With `resubscribe()` passing in an _already_ combined list, `bulkSubcribe()` would treat all existing subs as bulk subs.

### Problem 2
After calling `unsubscribe()` with the last handler for an individual topic, we were not remove it from the `this.subscriptions` list, so on the next `resubscribe()` call, it would still keep it in the sub list.


## Solution
1. In `resubscribe()`, we should only be passing in the already existing blukSubscriptions so we don't lose those, but more importantly, we should _not_ be combining our individual topics with the bulkSubs before "resubscribing" using `bulkSubscribe`.

1. When we unsubscribe from an individual topic and there are no more handlers, remove it from the internal tracked list so we don't keep the subscription.