### PR TITLE
PCM-1908 fixed timing WS out but not actually stopping stanza's connection attempt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     * `/v13.5.0/streaming-client.browser.js` (exact version)
     * `/v13/streaming-client.browser.js` (locked to latest for a specific major version)
 ### Fixed
+* [PCM-1908](https://inindca.atlassian.net/browse/PCM-1908) – fixing some `.connect()` functionality:
+    * `autoReconnect` no longer default to `true` but will be set to true after successfully connecting once
+    * when `connect()` times out, it will call through to stop any pending WS connect that stanza my still be attempting
+    * `connect()` will now reject when stanza emits a `--transport-disconnected` event which is what stanza emits when there
+        was a WS connection that failed or terminated. Note that stanza does not sufface the error, so we will be rejecting
+        with a generic error.
 * Addressed snyk and npm audit issues
 
 # [v13.4.1](https://github.com/purecloudlabs/genesys-cloud-streaming-client/compare/v13.4.0...v13.4.1)

--- a/src/http-client.ts
+++ b/src/http-client.ts
@@ -64,7 +64,7 @@ export class HttpClient {
     const value = this._httpRetryingRequests.get(retryId);
     if (value) {
       /* if the promise has already completed, this will do nothing. Still need to remove it from the map */
-      value.cancel(new Error('Retry request cancelled'));
+      value.reject(new Error('Retry request cancelled'));
       this._httpRetryingRequests.delete(retryId);
     }
     return true;

--- a/src/types/retry-utils.ts
+++ b/src/types/retry-utils.ts
@@ -1,0 +1,143 @@
+import { v4 } from 'uuid';
+import WildEmitter from 'wildemitter';
+
+export interface IRetryConfig<T = any> {
+  /**
+   * Function to attempt until it completes or rejects based on the
+   *  criteria for retrying.
+   */
+  promiseFn: () => Promise<T>;
+  /**
+   * Retry criteria to retry the promise function on failure. Available options:
+   * - `boolean`: if `true`, it will _always_ be retried. if `false`, it will _never_
+   *  be retried.
+   * - `number`: max attempts to retry
+   * - `function`: a function that accepts the error thrown and determines if it
+   *  should be retried. It will be passed the `Error` and the `attemptCount`.
+   *
+   * Default: `false`
+   */
+  retry?: boolean | number | ((error?: Error | any, attemptCount?: number) => boolean);
+  /**
+   * Milliseconds to wait inbetween next retry of the promise function on failure.
+   *
+   * Default: `15000`
+   */
+  retryInterval?: number;
+}
+
+type Required<T> = {
+  [P in keyof T]-?: T[P]
+};
+
+export class RetryPromise<T = any> extends WildEmitter {
+  promise: Promise<T>;
+  _id = v4();
+
+  private _reject!: (reason?: string | Error | any) => void;
+  private _resolve!: (value: T | PromiseLike<T>) => void;
+  private _hasCompleted = false;
+  private _attemptCount = 0;
+  private _timeout: any;
+  private _config: Required<IRetryConfig>;
+
+  constructor (config: IRetryConfig) {
+    super();
+    this.promise = new Promise((resolve, reject) => {
+      this._resolve = resolve;
+      this._reject = reject;
+    });
+
+    this._config = {
+      promiseFn: config.promiseFn,
+      retry: config.retry || false,
+      retryInterval: config.retryInterval !== undefined && config.retryInterval > -1 ? config.retryInterval : 15000
+    };
+
+    /* tslint:disable:no-floating-promises */
+    this._tryPromiseFn();
+  }
+
+  /**
+   * @deprecated use `reject(reason)`
+   * @param reason value to reject the promise with
+   * @returns void
+   */
+  cancel (reason?: string | Error | any): void {
+    return this.reject(reason);
+  }
+
+  reject (reason?: string | Error | any): void {
+    this._reject(reason);
+    clearTimeout(this._timeout);
+    this._hasCompleted = true;
+    this.emit('rejected', reason);
+  }
+
+  /**
+   * @deprecated use `resolve(reason)`
+   * @param value to resolve the promise with
+   * @returns void
+   */
+  complete (value: T | PromiseLike<T>) {
+    return this.resolve(value);
+  }
+
+  resolve (value: T | PromiseLike<T>) {
+    this._resolve(value);
+    clearTimeout(this._timeout);
+    this._hasCompleted = true;
+    this.emit('resolved', value);
+  }
+
+  hasCompleted (): boolean {
+    return this._hasCompleted;
+  }
+
+  attemptCount (): number {
+    return this._attemptCount;
+  }
+
+  private async _tryPromiseFn (): Promise<void> {
+    const { retry, retryInterval } = this._config;
+    try {
+      this._attemptCount++;
+
+      this.emit('trying', {
+        attemptCount: this._attemptCount,
+        promise: this.promise
+      });
+
+      const val = await this._config.promiseFn();
+      this.resolve(val);
+    } catch (error: any) {
+      if (
+        /* always retry */
+        retry === true ||
+        /* retry if under max retry attempts */
+        typeof retry === 'number' && this._attemptCount <= retry ||
+        /* retry if retry function returns true */
+        typeof retry === 'function' && retry(error, this._attemptCount + 1)
+      ) {
+        this.emit('retrying', {
+          error,
+          attemptCount: this._attemptCount,
+          retryInterval
+        });
+        this._timeout = setTimeout(this._tryPromiseFn.bind(this), retryInterval);
+        return;
+      }
+
+      this.reject(error);
+    }
+  }
+}
+
+export function retryPromise<T = any> (
+  promiseFn: () => Promise<T>,
+  retry?: boolean | number | ((error?: Error | any, attemptCount?: number) => boolean),
+  retryInterval: number = 15000,
+  _logger: any = console
+): RetryPromise<T> {
+  return new RetryPromise({ promiseFn, retry, retryInterval });
+}

--- a/test/scripts/ws-connect-issue.js
+++ b/test/scripts/ws-connect-issue.js
@@ -1,0 +1,26 @@
+window.client = new GenesysCloudStreamingClient(window.scConfig)
+
+let count = 0;
+const stanzaConnect = client._stanzaio.connect.bind(client._stanzaio);
+client._stanzaio._connect = () => {
+  count++;
+  console.log(`_stanzaio.connect(): ${count}`);
+  stanzaConnect();
+}
+
+client._stanzaio.on('--transport-disconnected', function () { console.log('stanza::', '--transport-disconnected', ...arguments) });
+client._stanzaio.on('session:started', function () { console.log('stanza::', 'session:started', ...arguments) });
+client._stanzaio.on('session:end', function () { console.log('stanza::', 'session:end', ...arguments) });
+
+client.connect()
+  .then(() => console.debug('CONNECTED'))
+  .catch(console.warn);
+
+window.debug = () => {
+  console.debug('==== DEBUG:', {
+    connected: client.connected,
+    connecting: client.connecting,
+    wsReadyState: client._stanzaio.transport && client._stanzaio.transport.socket.readyState,
+    channelId: client.config.channelId
+  });
+}

--- a/test/unit/reconnector.test.ts
+++ b/test/unit/reconnector.test.ts
@@ -391,6 +391,34 @@ describe('Reconnector', () => {
     });
   });
 
+  describe('_shouldRetryError()', () => {
+    let client: Client;
+    let reconnector: Reconnector;
+    let shouldRetryError: typeof Reconnector.prototype['_shouldRetryError'];
+    let error: Error;
+
+    beforeEach(() => {
+      client = new Client();
+      reconnector = new Reconnector(client);
+      shouldRetryError = reconnector['_shouldRetryError'].bind(reconnector);
+      error = new Error('never retry me');
+    });
+
+    it('should return true if maxattempt number has not been met', () => {
+      expect(shouldRetryError(error, 1, 2)).toBe(true);
+      expect(shouldRetryError(error, 2, 2)).toBe(true);
+    });
+
+    it('should return false if maxattempt or attemptnumber are not of type number', () => {
+      expect(shouldRetryError(error, undefined, 2)).toBe(false);
+      expect(shouldRetryError(error, 1, undefined)).toBe(false);
+    });
+
+    it('should return false if maxattempts have been reached', () => {
+      expect(shouldRetryError(error, 3, 2)).toBe(false);
+    });
+  });
+
   it('when an auth failure occurs it will cease the backoff', () => {
     const client = new Client();
     const reconnect = new Reconnector(client);

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -1,5 +1,5 @@
 import * as utils from '../../src/utils';
-import { retryPromise } from '../../src/utils';
+import { retryPromise, RetryPromise } from '../../src/utils';
 
 describe('Utils', () => {
   describe('jid utils', () => {
@@ -74,6 +74,14 @@ describe('Utils', () => {
       await flush(DELAY);
       expect(retryFn).toHaveBeenCalledTimes(4);
       expect(retry.hasCompleted()).toBe(true);
+    });
+  });
+
+  describe('RetryPromise', () => {
+    it('should export RetryPromise',  () => {
+      return new RetryPromise({
+        promiseFn: () => Promise.resolve()
+      });
     });
   });
 });


### PR DESCRIPTION
## Problem
1. if we timed out `sc.connect()` after the 10 seconds but stanza's WS is still trying to connect, it is possible that i connects _after_ we have rejected with the timeout. So consumers would have already tried to connect another WS. 
1. sometimes our retry on disconnect logic would kick in when stanza ran into an error connecting. This could cause the retry logic in the backgroung to start even though we had already rejected `sc.connect()` 

## Solution
1. when `sc.connect()` times out, we tell stanza to stop any pending connection
2. when `sc.connect()` calls stanza, it listens for `--transport-disconnect` events from stanza and rejects on them (since this is what stanza emits when a WS failed)
3. we do not turn on our retry logic until _after_ successfully connecting. 