### PR TITLE
[STREAM-153] Don't stop sending stats when server logging is stopped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # [Unreleased](https://github.com/purecloudlabs/genesys-cloud-streaming-client/compare/v17.2.3...HEAD)
 * [STREAM-146](https://inindca.atlassian.net/browse/STREAM-146) - Update logging for new JSON-RPC commands.
 * [STREAM-69](https://inindca.atlassian.net/browse/STREAM-69) - Don't send stats when offline and start sending stats again when online.
+* [STREAM-153](https://inindca.atlassian.net/browse/STREAM-153) - Don't stop sending stats when stopping server logging.
 
 # [v17.2.3](https://github.com/purecloudlabs/genesys-cloud-streaming-client/compare/v17.2.2...v17.2.3)
 ### Fixed

--- a/src/client.ts
+++ b/src/client.ts
@@ -649,9 +649,8 @@ export class Client extends EventEmitter {
   }
 
   stopServerLogging () {
-    /* flush all pending logs and webrtc stats – then turn off the logger */
+    /* flush all pending logs – then turn off the logger */
     this.logger.sendAllLogsInstantly();
-    this._webrtcSessions.sendStatsImmediately();
     this.logger.stopServerLogging();
   }
 

--- a/src/webrtc.ts
+++ b/src/webrtc.ts
@@ -374,11 +374,6 @@ export class WebrtcExtension extends EventEmitter implements StreamingClientExte
   // This should be moved when the sdk is the primary consumer
   proxyStatsForSession (session: IMediaSession) {
     session.on('stats', (statsEvent: StatsEvent) => {
-      /* if our logger was stopped, we need to stop stats logging too */
-      if (this.client.logger['stopReason']) {
-        return;
-      }
-
       const statsCopy = JSON.parse(JSON.stringify(statsEvent));
       const extraDetails = {
         conversationId: (session as any).conversationId,

--- a/test/unit/webrtc.test.ts
+++ b/test/unit/webrtc.test.ts
@@ -1422,23 +1422,6 @@ describe('proxyStatsForSession', () => {
     expect(webrtc['statsArr']).toEqual([formattedStats]);
     expect(webrtc['throttledSendStats'].flush).toHaveBeenCalled();
   });
-
-  it('should not proxy stats if the logger has stopped', () => {
-    const client = new Client({});
-    const webrtc = new WebrtcExtension(client as any, {} as any);
-    const session: any = new EventEmitter();
-
-    const spy = jest.spyOn(statsFormatter, 'formatStatsEvent');
-
-    webrtc.proxyStatsForSession(session);
-    client.logger['stopReason'] = '401';
-
-    session.emit('stats', {
-      actionName: 'test'
-    });
-
-    expect(spy).not.toHaveBeenCalled();
-  });
 });
 
 describe('sendStats', () => {


### PR DESCRIPTION
Looks like this was added in https://github.com/purecloudlabs/genesys-cloud-streaming-client/commit/c677108b10905bf8d41feddfea5bbe04538dce7d

I noticed it while working on [STREAM-69] and Garrett said it was a bug.

[STREAM-69]: https://inindca.atlassian.net/browse/STREAM-69?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ