### PR TITLE
[PCM-2081] Use server generated links for video conference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 # [Unreleased](https://github.com/purecloudlabs/genesys-cloud-streaming-client/compare/v18.0.0...HEAD)
-### Changed
-* [STREAM-313](https://inindca.atlassian.net/browse/STREAM-313) - Streaming-client will ignore duplicate reinvite offers.
-
 ### Breaking Changes
 * Lru-cache was upgraded from v6 to v11, which uses newer language features. Depending on your language target version, you may need to configure a transpiler accordingly. For example, we added `plugin-proposal-class-properties` and `plugin-transform-private-methods` to our Babel config for streaming-client.
+
+### Changed
+* [STREAM-313](https://inindca.atlassian.net/browse/STREAM-313) - Streaming-client will ignore duplicate reinvite offers.
+* [PCM-2081](https://inindca.atlassian.net/browse/PCM-2081) - Set meetingId when initializing GenesysCloudMediaSessions and only delete pending sessions when processed for the right session type.
 
 ### Fixed
 * [STREAM-207](https://inindca.atlassian.net/browse/STREAM-207) - [STREAM-207] handle ice candidates received before the offer (sdpOverXmpp only)

--- a/src/types/genesys-cloud-media-session.ts
+++ b/src/types/genesys-cloud-media-session.ts
@@ -57,6 +57,7 @@ export class GenesysCloudMediaSession {
     this.allowTCP = !!params.allowTCP;
     this.reinvite = !!params.reinvite;
     this.privAnswerMode = params.privAnswerMode;
+    this.meetingId = params.meetingId;
 
     // babel does not like the typescript recipe for multiple extends so we are hacking this one
     // referencing https://github.com/babel/babel/issues/798

--- a/src/webrtc.ts
+++ b/src/webrtc.ts
@@ -262,6 +262,7 @@ export class WebrtcExtension extends EventEmitter implements StreamingClientExte
         originalRoomJid: pendingSession.originalRoomJid,
         privAnswerMode: pendingSession.privAnswerMode
       };
+      delete this.pendingSessions[pendingSession.sessionId];
     } else {
       mediaSessionParams = commonParams;
     }
@@ -382,18 +383,16 @@ export class WebrtcExtension extends EventEmitter implements StreamingClientExte
     }
   }
 
-  prepareSession (options: SessionOpts) {
+  prepareSession (options: SessionOpts): StanzaMediaSession | undefined {
     const pendingSession = this.pendingSessions[options.sid!];
-
-    // TODO: when we can safely remove the jingle session handling, this pending session
-    // will need to be deleted in the `handleGenesysOffer` fn.
-    if (pendingSession) {
-      delete this.pendingSessions[pendingSession.sessionId];
-    }
 
     if (pendingSession?.sdpOverXmpp) {
       this.logger.debug('skipping creation of jingle webrtc session due to sdpOverXmpp on the pendingSession');
       return;
+    }
+
+    if (pendingSession) {
+      delete this.pendingSessions[pendingSession.sessionId];
     }
 
     const ignoreHostCandidatesForForceTurnFF = this.getIceTransportPolicy() === 'relay' && isFirefox;


### PR DESCRIPTION
Support for meetingIds was added in https://github.com/purecloudlabs/genesys-cloud-streaming-client/pull/207, but there were a couple of things that got missed at the time:

- GenesysCloudMediaSessions were not setting the meetingId when initialized
- Even though `prepareSession` defers most of the work for GenesysCloudMediaSessions to `handleGenesysOffer`, it was deleting pending sessions, which was a problem if it was called first. (Aside, it looks like we get the offer and session-initiate in a different order for softphone and for video. This should keep it working no matter what order we receive them in.)