### PR TITLE
[STREAM-326] streaming client is emitting a pendingSession event for jingle and json-rpc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 * [STREAM-207](https://inindca.atlassian.net/browse/STREAM-207) - [STREAM-207] handle ice candidates received before the offer (sdpOverXmpp only)
+* [STREAM-326](https://inindca.atlassian.net/browse/STREAM-326) - Only delete pending sessions when handling Jingle session-initiate to avoid emitting two sessions (partial reversion of d1251b22c1b82ddd0b514a5384a89510082dda26).
 
 # [v18.0.0](https://github.com/purecloudlabs/genesys-cloud-streaming-client/compare/v17.2.7...v18.0.0)
 ### Breaking Changes

--- a/src/webrtc.ts
+++ b/src/webrtc.ts
@@ -262,7 +262,6 @@ export class WebrtcExtension extends EventEmitter implements StreamingClientExte
         originalRoomJid: pendingSession.originalRoomJid,
         privAnswerMode: pendingSession.privAnswerMode
       };
-      delete this.pendingSessions[pendingSession.sessionId];
     } else {
       mediaSessionParams = commonParams;
     }
@@ -386,13 +385,15 @@ export class WebrtcExtension extends EventEmitter implements StreamingClientExte
   prepareSession (options: SessionOpts): StanzaMediaSession | undefined {
     const pendingSession = this.pendingSessions[options.sid!];
 
+    // TODO: when we can safely remove the jingle session handling, this pending session
+    // will need to be deleted in the `handleGenesysOffer` fn.
+    if (pendingSession) {
+      delete this.pendingSessions[pendingSession.sessionId];
+    }
+
     if (pendingSession?.sdpOverXmpp) {
       this.logger.debug('skipping creation of jingle webrtc session due to sdpOverXmpp on the pendingSession');
       return;
-    }
-
-    if (pendingSession) {
-      delete this.pendingSessions[pendingSession.sessionId];
     }
 
     const ignoreHostCandidatesForForceTurnFF = this.getIceTransportPolicy() === 'relay' && isFirefox;

--- a/test/unit/webrtc.test.ts
+++ b/test/unit/webrtc.test.ts
@@ -263,28 +263,6 @@ describe('prepareSession', () => {
     expect(Object.values(webrtc.pendingSessions).length).toBe(0);
   });
 
-  it('should not delete pending session if sdpOverXmpp', () => {
-    (StanzaMediaSession as jest.Mock).mockReset();
-    StanzaMediaSession.prototype.on = jest.fn();
-    const client = new Client({});
-    const webrtc = new WebrtcExtension(client as any, {} as any);
-
-    webrtc.pendingSessions['mysid'] = {
-      sessionId: 'mysid',
-      sdpOverXmpp: true,
-      autoAnswer: false,
-      id: 'myid',
-      toJid: 'tojid',
-      fromJid: 'fromjid',
-      conversationId: 'myconvo',
-      sessionType: SessionTypes.collaborateVideo
-    };
-
-    expect(Object.values(webrtc.pendingSessions).length).toBe(1);
-    const session = webrtc.prepareSession({ sid: 'mysid' } as any);
-    expect(Object.values(webrtc.pendingSessions).length).toBe(1);
-  });
-
   it('should use sessionType from pendingSession', () => {
     (StanzaMediaSession as jest.Mock).mockReset();
     StanzaMediaSession.prototype.on = jest.fn();
@@ -2164,37 +2142,6 @@ describe('handleGenesysOffer', () => {
     };
 
     await webrtc['handleGenesysOffer'](iq);
-  });
-
-  it('should delete pending session', async () => {
-    const iq: IQ = {
-      type: 'set',
-      from: 'fromJid25@gjoll.com',
-      genesysWebrtc: {
-        jsonrpc: '2.0',
-        method: 'offer',
-        params: {
-          conversationId: 'convo25',
-          sessionId: 'session25',
-          sdp: 'my-offer'
-        }
-      }
-    };
-
-    webrtc.pendingSessions['session25'] = {
-      autoAnswer: true,
-      conversationId: 'convo25',
-      fromJid: 'fromJid25@gjoll.com',
-      id: 'session25',
-      sessionId: 'session25',
-      sessionType: 'softphone',
-      toJid: 'tojid25',
-      fromUserId: 'fromUserId26'
-    };
-
-    expect(Object.values(webrtc.pendingSessions).length).toBe(1);
-    await webrtc['handleGenesysOffer'](iq);
-    expect(Object.values(webrtc.pendingSessions).length).toBe(0);
   });
 });
 


### PR DESCRIPTION
This reverts the code from https://github.com/purecloudlabs/genesys-cloud-streaming-client/pull/277 that changed the behavior around deleting pending sessions, which caused the bug where both the Jingle handler and the SDP over XMPP handler emitted sessions.

The other parts of #277 are still valid.