### PR TITLE
[STREAM-155] Calling `disconnect` will stop any in-progress connection attempts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-# [Unreleased](https://github.com/purecloudlabs/genesys-cloud-client-logger/compare/19.2.2...HEAD)
-### Changed
-* [STREAM-643](https://inindca.atlassian.net/browse/STREAM-643) - Bumped webpack dependency to 5.94.0
-
 # [Unreleased](https://github.com/purecloudlabs/genesys-cloud-streaming-client/compare/v19.2.2...HEAD)
 ### Changed
 * [STREAM-631](https://inindca.atlassian.net/browse/STREAM-631) - Remove pipeline infra from open-source.
+* [STREAM-643](https://inindca.atlassian.net/browse/STREAM-643) - Bumped webpack dependency to 5.94.0
+
+### Fixed
+* [STREAM-155](https://inindca.atlassian.net/browse/STREAM-155) - Calling `disconnect` will now stop any in-progress connection attempts.
 
 # [v19.2.2](https://github.com/purecloudlabs/genesys-cloud-streaming-client/compare/v19.2.1...v19.2.2)
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # [Unreleased](https://github.com/purecloudlabs/genesys-cloud-streaming-client/compare/v19.2.2...HEAD)
 ### Changed
 * [STREAM-631](https://inindca.atlassian.net/browse/STREAM-631) - Remove pipeline infra from open-source.
-* [STREAM-643](https://inindca.atlassian.net/browse/STREAM-643) - Bumped webpack dependency to 5.94.0
 
 ### Fixed
 * [STREAM-155](https://inindca.atlassian.net/browse/STREAM-155) - Calling `disconnect` will now stop any in-progress connection attempts.

--- a/src/client.ts
+++ b/src/client.ts
@@ -52,6 +52,7 @@ export class Client extends EventEmitter {
   backgroundAssistantMode = false;
 
   private autoReconnect = true;
+  private cancelConnectionAttempt = false;
   private extensions: StreamingClientExtension[] = [];
   private connectionManager: ConnectionManager;
   private channelReuses = 0;
@@ -288,6 +289,7 @@ export class Client extends EventEmitter {
 
     return timeoutPromise(resolve => {
       this.autoReconnect = false;
+      this.cancelConnectionAttempt = true;
       this.http.stopAllRetries();
       this.connectionManager.currentStanzaInstance?.disconnect()?.then(resolve) ?? resolve();
     }, 5000, 'disconnecting streaming service');

--- a/src/client.ts
+++ b/src/client.ts
@@ -376,6 +376,7 @@ export class Client extends EventEmitter {
   }
 
   async connect (connectOpts?: StreamingClientConnectOptions) {
+    this.cancelConnectionAttempt = false;
     if (this.connecting) {
       const error = new Error('Already trying to connect streaming client');
       return this.logger.warn(error);

--- a/src/client.ts
+++ b/src/client.ts
@@ -280,12 +280,8 @@ export class Client extends EventEmitter {
     this.hardReconnectRequired = true;
   }
 
-  async disconnect () {
+  async disconnect (): Promise<any> {
     this.logger.info('streamingClient.disconnect was called');
-
-    if (!this.activeStanzaInstance) {
-      return;
-    }
 
     // Clear stored JID on client disconnect.
     this.jidResource = '';
@@ -293,8 +289,7 @@ export class Client extends EventEmitter {
     return timeoutPromise(resolve => {
       this.autoReconnect = false;
       this.http.stopAllRetries();
-      return this.activeStanzaInstance!.disconnect()
-        .then(resolve);
+      this.connectionManager.currentStanzaInstance?.disconnect()?.then(resolve) ?? resolve();
     }, 5000, 'disconnecting streaming service');
   }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -475,6 +475,8 @@ export class Client extends EventEmitter {
   }
 
   private async backoffConnectRetryHandler (connectOpts: { maxConnectionAttempts: number }, err: any, connectionAttempt: number): Promise<boolean> {
+    // Check `cancelConnectionAttempt` instead of the error type in case a different error occurred
+    // around the same time that might allow for retries to continue.
     if (this.cancelConnectionAttempt) {
       return false;
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -24,6 +24,7 @@ import { TimeoutError } from './types/timeout-error';
 import { MessengerExtensionApi, MessengerExtension } from './messenger';
 import { SASLFailureCondition } from 'stanza/Constants';
 import { v4 } from 'uuid';
+import UserCanceledError from './types/user-canceled-error';
 
 let extensions = {
   notifications: Notifications,
@@ -564,6 +565,11 @@ export class Client extends EventEmitter {
   }
 
   private async makeConnectionAttempt () {
+    if (this.cancelConnectionAttempt) {
+      console.log('Hjon: makeConnectionAttempt:throwingCancelErrorBeforeOnlineCheck');
+      throw new UserCanceledError('Connection attempt canceled');
+    }
+
     if (!navigator.onLine) {
       throw new OfflineError('Browser is offline, skipping connection attempt');
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -583,7 +583,6 @@ export class Client extends EventEmitter {
 
   private async makeConnectionAttempt () {
     if (this.cancelConnectionAttempt) {
-      console.log('Hjon: makeConnectionAttempt:throwingCancelErrorBeforeOnlineCheck');
       throw new UserCanceledError('Connection attempt canceled');
     }
 
@@ -597,7 +596,6 @@ export class Client extends EventEmitter {
       await this.prepareForConnect();
 
       if (this.cancelConnectionAttempt) {
-        console.log('Hjon: makeConnectionAttempt:throwingCancelError');
         throw new UserCanceledError('Connection attempt canceled');
       }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -475,6 +475,10 @@ export class Client extends EventEmitter {
   }
 
   private async backoffConnectRetryHandler (connectOpts: { maxConnectionAttempts: number }, err: any, connectionAttempt: number): Promise<boolean> {
+    if (this.cancelConnectionAttempt) {
+      return false;
+    }
+
     // if we exceed the `numOfAttempts` in the backoff config it still calls this retry fn and just ignores the result
     // if that's the case, we just want to bail out and ignore all the extra logging here.
     if (connectionAttempt >= connectOpts.maxConnectionAttempts) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -24,7 +24,7 @@ import { TimeoutError } from './types/timeout-error';
 import { MessengerExtensionApi, MessengerExtension } from './messenger';
 import { SASLFailureCondition } from 'stanza/Constants';
 import { v4 } from 'uuid';
-import UserCanceledError from './types/user-canceled-error';
+import UserCancelledError from './types/user-cancelled-error';
 
 let extensions = {
   notifications: Notifications,
@@ -444,7 +444,7 @@ export class Client extends EventEmitter {
       // Check `cancelConnectionAttempt` instead of the error type in case a different error occurred
       // around the same time that might mask the cancellation.
       if (this.cancelConnectionAttempt) {
-        errorForThrowing = new StreamingClientError(StreamingClientErrorTypes.userCanceled, 'Streaming client connection canceled', err);
+        errorForThrowing = new StreamingClientError(StreamingClientErrorTypes.userCancelled, 'Streaming client connection cancelled', err);
         errorForLogging = errorForThrowing;
       } else if (!err) {
         errorForThrowing = new StreamingClientError(StreamingClientErrorTypes.generic, 'Streaming client connection attempted and received an undefined error');
@@ -583,7 +583,7 @@ export class Client extends EventEmitter {
 
   private async makeConnectionAttempt () {
     if (this.cancelConnectionAttempt) {
-      throw new UserCanceledError('Connection attempt canceled');
+      throw new UserCancelledError('Connection attempt cancelled');
     }
 
     if (!navigator.onLine) {
@@ -596,7 +596,7 @@ export class Client extends EventEmitter {
       await this.prepareForConnect();
 
       if (this.cancelConnectionAttempt) {
-        throw new UserCanceledError('Connection attempt canceled');
+        throw new UserCancelledError('Connection attempt cancelled');
       }
 
       stanzaInstance = await this.connectionManager.getNewStanzaConnection();

--- a/src/client.ts
+++ b/src/client.ts
@@ -292,7 +292,12 @@ export class Client extends EventEmitter {
       this.autoReconnect = false;
       this.cancelConnectionAttempt = true;
       this.http.stopAllRetries();
-      this.connectionManager.currentStanzaInstance?.disconnect()?.then(resolve) ?? resolve();
+      const currentStanza = this.connectionManager.currentStanzaInstance;
+      if (currentStanza) {
+        return currentStanza.disconnect().then(resolve);
+      } else {
+        resolve();
+      }
     }, 5000, 'disconnecting streaming service');
   }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -578,6 +578,12 @@ export class Client extends EventEmitter {
     let previousConnectingState = this.connecting;
     try {
       await this.prepareForConnect();
+
+      if (this.cancelConnectionAttempt) {
+        console.log('Hjon: makeConnectionAttempt:throwingCancelError');
+        throw new UserCanceledError('Connection attempt canceled');
+      }
+
       stanzaInstance = await this.connectionManager.getNewStanzaConnection();
       this.connected = true;
       this.connecting = false;

--- a/src/client.ts
+++ b/src/client.ts
@@ -435,7 +435,13 @@ export class Client extends EventEmitter {
     } catch (err: any) {
       let errorForThrowing: StreamingClientError;
       let errorForLogging = err;
-      if (!err) {
+
+      // Check `cancelConnectionAttempt` instead of the error type in case a different error occurred
+      // around the same time that might mask the cancellation.
+      if (this.cancelConnectionAttempt) {
+        errorForThrowing = new StreamingClientError(StreamingClientErrorTypes.userCanceled, 'Streaming client connection canceled', err);
+        errorForLogging = errorForThrowing;
+      } else if (!err) {
         errorForThrowing = new StreamingClientError(StreamingClientErrorTypes.generic, 'Streaming client connection attempted and received an undefined error');
         errorForLogging = errorForThrowing;
       } else if (err.name === 'AxiosError') {

--- a/src/connection-manager.ts
+++ b/src/connection-manager.ts
@@ -17,6 +17,8 @@ import SaslError from './types/sasl-error';
 import { parseJwt, timeoutPromise } from './utils';
 
 export class ConnectionManager {
+  currentStanzaInstance?: NamedAgent;
+
   constructor (private logger: Logger, private config: IClientConfig) {}
 
   setConfig (config: IClientConfig) {
@@ -26,6 +28,7 @@ export class ConnectionManager {
   async getNewStanzaConnection (): Promise<NamedAgent> {
     const options = this.getStanzaOptions();
     const stanza = createClient({}) as unknown as NamedAgent;
+    this.currentStanzaInstance = stanza;
 
     // this is a hack because stanza messes up the auth mechanism priority.
     (stanza.sasl as any).mechanisms.find(mech => mech.name === 'ANONYMOUS').priority = 0;

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -114,7 +114,7 @@ export interface IResponseError extends IError {
 export enum StreamingClientErrorTypes {
   generic = 'generic',
   invalid_token = 'invalid_token',
-  userCanceled = 'user_canceled'
+  userCancelled = 'user_cancelled'
 }
 
 export interface IError {

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -113,7 +113,8 @@ export interface IResponseError extends IError {
 
 export enum StreamingClientErrorTypes {
   generic = 'generic',
-  invalid_token = 'invalid_token'
+  invalid_token = 'invalid_token',
+  userCanceled = 'user_canceled'
 }
 
 export interface IError {

--- a/src/types/user-canceled-error.ts
+++ b/src/types/user-canceled-error.ts
@@ -1,0 +1,1 @@
+export default class UserCanceledError extends Error {}

--- a/src/types/user-canceled-error.ts
+++ b/src/types/user-canceled-error.ts
@@ -1,1 +1,0 @@
-export default class UserCanceledError extends Error {}

--- a/src/types/user-cancelled-error.ts
+++ b/src/types/user-cancelled-error.ts
@@ -1,0 +1,1 @@
+export default class UserCancelledError extends Error {}

--- a/test/unit/client.test.ts
+++ b/test/unit/client.test.ts
@@ -15,6 +15,7 @@ import { flushPromises } from '../helpers/testing-utils';
 import { SCConnectionData, StreamingClientErrorTypes, StreamingClientError } from '../../src';
 import { Ping } from '../../src/ping';
 import { ServerMonitor } from '../../src/server-monitor';
+import UserCanceledError from '../../src/types/user-canceled-error';
 
 jest.mock('genesys-cloud-client-logger');
 jest.mock('../../src/ping');
@@ -809,6 +810,14 @@ describe('makeConnectionAttempt', () => {
     getConnectionSpy = client['connectionManager'].getNewStanzaConnection = jest.fn();
 
     pingerMock.mockClear();
+  });
+
+  it('should not attempt if the connection attempt has been canceled', async () => {
+    client['cancelConnectionAttempt'] = true;
+
+    await expect(client['makeConnectionAttempt']()).rejects.toThrow(UserCanceledError);
+    expect(prepareSpy).not.toHaveBeenCalled();
+    expect(getConnectionSpy).not.toHaveBeenCalled();
   });
 
   it('should not attempt if offline', async () => {

--- a/test/unit/client.test.ts
+++ b/test/unit/client.test.ts
@@ -589,8 +589,17 @@ describe('backoffConnectRetryHandler', () => {
   });
 
   it('should return false if cancelConnectionAttempt is true', async () => {
+    const error = new UserCanceledError('user canceled');
     client['cancelConnectionAttempt'] = true;
-    const result = await client['backoffConnectRetryHandler']({ maxConnectionAttempts: 10 }, {}, 1)
+    const result = await client['backoffConnectRetryHandler']({ maxConnectionAttempts: 10 }, error, 1);
+    expect(result).toBeFalsy();
+  });
+
+  it('should return false if cancelConnectionAttempt is true even if called with another error', async () => {
+    const error = new TimeoutError('fake timeout');
+    client['cancelConnectionAttempt'] = true;
+
+    const result = await client['backoffConnectRetryHandler']({ maxConnectionAttempts: 2 }, error, 1);
     expect(result).toBeFalsy();
   });
 

--- a/test/unit/client.test.ts
+++ b/test/unit/client.test.ts
@@ -520,6 +520,7 @@ describe('disconnect', () => {
 
   beforeEach(() => {
     client = new Client(getDefaultOptions());
+    client['autoReconnect'] = true;
   });
 
   it('should stop HTTP retries and resolve when there is a current stanza instance', async () => {
@@ -547,6 +548,8 @@ describe('disconnect', () => {
     await flushPromises();
 
     expect(isResolved).toBeTruthy();
+    expect(client['autoReconnect']).toBeFalsy();
+    expect(client['cancelConnectionAttempt']).toBeTruthy();
   });
 
   it('should stop HTTP retries and resolve when there is no current stanza instance', async () => {
@@ -555,11 +558,12 @@ describe('disconnect', () => {
     client.http.stopAllRetries = jest.fn();
     client['connectionManager'].currentStanzaInstance = undefined;
 
-    const promise = client.disconnect().then(() => isResolved = true);
-    await flushPromises();
+    await client.disconnect().then(() => isResolved = true);
 
     expect(client.http.stopAllRetries).toHaveBeenCalled();
     expect(isResolved).toBeTruthy();
+    expect(client['autoReconnect']).toBeFalsy();
+    expect(client['cancelConnectionAttempt']).toBeTruthy();
   });
 });
 

--- a/test/unit/client.test.ts
+++ b/test/unit/client.test.ts
@@ -270,6 +270,14 @@ describe('connect', () => {
     backoffRetrySpy = client['backoffConnectRetryHandler'] = jest.fn();
   });
 
+  it('should set cancelConnectionAttempt to false', async () => {
+    connectionAttemptSpy.mockResolvedValue(null);
+    client['cancelConnectionAttempt'] = true;
+
+    await client.connect();
+    expect(client['cancelConnectionAttempt']).toBeFalsy();
+  });
+
   it('should do nothing if already connecting', async () => {
     client.connecting = true;
     await client.connect();

--- a/test/unit/client.test.ts
+++ b/test/unit/client.test.ts
@@ -14,7 +14,7 @@ import { flushPromises } from '../helpers/testing-utils';
 import { SCConnectionData, StreamingClientErrorTypes, StreamingClientError } from '../../src';
 import { Ping } from '../../src/ping';
 import { ServerMonitor } from '../../src/server-monitor';
-import UserCanceledError from '../../src/types/user-canceled-error';
+import UserCancelledError from '../../src/types/user-cancelled-error';
 
 jest.mock('genesys-cloud-client-logger');
 jest.mock('../../src/ping');
@@ -349,7 +349,7 @@ describe('connect', () => {
     expect.assertions(4);
   });
 
-  it('should throw a user_canceled error if the connection attempt was canceled regardless of the thrown error', async () => {
+  it('should throw a user_cancelled error if the connection attempt was cancelled regardless of the thrown error', async () => {
     const error = new SaslError('incorrect-encoding', 'channelId', 'instanceId');
     connectionAttemptSpy.mockRejectedValue(error);
     connectionAttemptSpy.mockImplementation(() => {
@@ -361,7 +361,7 @@ describe('connect', () => {
       await client.connect({ keepTryingOnFailure: false });
     } catch (err) {
       expect(err).toBeInstanceOf(StreamingClientError);
-      expect(err['type']).toBe(StreamingClientErrorTypes.userCanceled);
+      expect(err['type']).toBe(StreamingClientErrorTypes.userCancelled);
       expect(err['details']).toBe(error);
     }
     expect(connectionAttemptSpy).toHaveBeenCalledTimes(1);
@@ -607,7 +607,7 @@ describe('backoffConnectRetryHandler', () => {
   });
 
   it('should return false if cancelConnectionAttempt is true', async () => {
-    const error = new UserCanceledError('user canceled');
+    const error = new UserCancelledError('user cancelled');
     client['cancelConnectionAttempt'] = true;
     const result = await client['backoffConnectRetryHandler']({ maxConnectionAttempts: 10 }, error, 1);
     expect(result).toBeFalsy();
@@ -845,10 +845,10 @@ describe('makeConnectionAttempt', () => {
     pingerMock.mockClear();
   });
 
-  it('should not attempt if the connection attempt has been canceled', async () => {
+  it('should not attempt if the connection attempt has been cancelled', async () => {
     client['cancelConnectionAttempt'] = true;
 
-    await expect(client['makeConnectionAttempt']()).rejects.toThrow(UserCanceledError);
+    await expect(client['makeConnectionAttempt']()).rejects.toThrow(UserCancelledError);
     expect(prepareSpy).not.toHaveBeenCalled();
     expect(getConnectionSpy).not.toHaveBeenCalled();
   });
@@ -863,10 +863,10 @@ describe('makeConnectionAttempt', () => {
     spy.mockRestore();
   });
 
-  it('should not set up a stanza instance if the connection attempt is canceled after preparing to connect', async () => {
+  it('should not set up a stanza instance if the connection attempt is cancelled after preparing to connect', async () => {
     prepareSpy.mockImplementation(() => client['cancelConnectionAttempt'] = true);
 
-    await expect(client['makeConnectionAttempt']()).rejects.toThrow(UserCanceledError);
+    await expect(client['makeConnectionAttempt']()).rejects.toThrow(UserCancelledError);
 
     expect(prepareSpy).toHaveBeenCalled();
     expect(getConnectionSpy).not.toHaveBeenCalled();

--- a/test/unit/client.test.ts
+++ b/test/unit/client.test.ts
@@ -830,6 +830,15 @@ describe('makeConnectionAttempt', () => {
     spy.mockRestore();
   });
 
+  it('should not set up a stanza instance if the connection attempt is canceled after preparing to connect', async () => {
+    prepareSpy.mockImplementation(() => client['cancelConnectionAttempt'] = true);
+
+    await expect(client['makeConnectionAttempt']()).rejects.toThrow(UserCanceledError);
+
+    expect(prepareSpy).toHaveBeenCalled();
+    expect(getConnectionSpy).not.toHaveBeenCalled();
+  });
+
   it('should set up stanzaInstance and emit connected event', async () => {
     expect.assertions(8);
     const fakeInstance = {};

--- a/test/unit/client.test.ts
+++ b/test/unit/client.test.ts
@@ -588,6 +588,12 @@ describe('backoffConnectRetryHandler', () => {
     errorSpy = jest.spyOn(client.logger, 'error');
   });
 
+  it('should return false if cancelConnectionAttempt is true', async () => {
+    client['cancelConnectionAttempt'] = true;
+    const result = await client['backoffConnectRetryHandler']({ maxConnectionAttempts: 10 }, {}, 1)
+    expect(result).toBeFalsy();
+  });
+
   it('should return false if not keepTryingOnFailure', async () => {
     expect(await client['backoffConnectRetryHandler']({ maxConnectionAttempts: 1 }, {}, 1)).toBeFalsy();
   });


### PR DESCRIPTION
Some notes on implementation:
- As Stanza is connecting, but before it has fully connected, we don't have a means to access it and disconnect it. I added the `currentStanzaInstance` to ConnectionManager to allow for that.
- However, it's also possible that one might call `disconnect` any time after calling `connect` and before Stanza is connected. I added `cancelConnectionAttempt` as a flag we can check to stop any in-progress connection attempt.
- In my mind, if someone has canceled a connection attempt, that should be what we report as any error that might be thrown. For example, I think that it would be confusing to cancel a connection attempt and receive an `invalid_token` error (even if that *also* happened during the connection attempt). But it also makes sense to include that secondary error for more context.

And finally:
> The forms of *cancel* in American English are typically *canceled* and *canceling*; in British English they are *cancelled* and *cancelling*.

- From https://www.merriam-webster.com/dictionary/cancel

I add that somewhat jokingly. I think my personal usage is not entirely consistent (though I tried to be for this PR) and I'm ok with using either spelling. 🙂