### PR TITLE
[STREAM-1095] Set `connected` just before emitting the `connected` event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [STREAM-2184](https://inindca.atlassian.net/browse/STREAM-2184) - Update stanza to v12.22.1
 * [STREAM-2176](https://inindca.atlassian.net/browse/STREAM-2176) - Allow userId to be passed in as a client option so it doesn't need to be fetched again
 * [STREAM-2207](https://inindca.atlassian.net/browse/STREAM-2207) - Debounce `claimAlertingLeader` to prevent hammering the endpoint
+* [STREAM-1095](https://inindca.atlassian.net/browse/STREAM-1095) - Set `connected` just before emitting the `connected` event to avoid a gap where an extension might see `connected` as `true` but not have the current stanza instance internally yet.
 
 # [v20.0.1](https://github.com/purecloudlabs/genesys-cloud-streaming-client/compare/v20.0.0...v20.0.1)
 ### Changed

--- a/src/client.ts
+++ b/src/client.ts
@@ -661,8 +661,6 @@ export class Client extends EventEmitter {
       }
 
       stanzaInstance = await this.connectionManager.getNewStanzaConnection();
-      this.connected = true;
-      this.connecting = false;
       this.addInateEventHandlers(stanzaInstance);
       this.proxyStanzaEvents(stanzaInstance);
 
@@ -677,9 +675,11 @@ export class Client extends EventEmitter {
         extension.handleStanzaInstanceChange(stanzaInstance);
       }
 
-      this.activeStanzaInstance = stanzaInstance;
-
       await this.setupConnectionMonitoring(stanzaInstance);
+
+      this.activeStanzaInstance = stanzaInstance;
+      this.connected = true;
+      this.connecting = false;
       this.emit('connected');
     } catch (err) {
       if (stanzaInstance) {

--- a/test/unit/client.test.ts
+++ b/test/unit/client.test.ts
@@ -969,48 +969,52 @@ describe('makeConnectionAttempt', () => {
 
   /*
   *  This is to guard an issue where an extension checked the `connected` property but didn't have
-  *  the new stanza instance via `handleStanzaInstanceChange` yet. The extension could be more defensive
+  *  the new stanza instance via `handleStanzaInstanceChange` yet. There are other ways to fix this
   *  but it seemed like a good idea for the property and the event to be more closely tied.
   */
-  it('should not set `connected` to `true` until just before emitting the event', async () => {
-    expect.assertions(12);
-    const fakeInstance = {
+  it('should not set `connected` to `true` until emitting the event', async () => {
+    interface Trace {
+      label: string;
+      connected: boolean;
+      connecting: boolean;
+    }
+    const traces: Trace[] = [];
+    const record = (label: string) => traces.push({ label, connected: client.connected, connecting: client.connecting });
+
+    const fakeStanzaInstance = {
       on: jest.fn(),
       stanzas: {
         define: jest.fn()
       }
     };
-    getConnectionSpy.mockResolvedValue(fakeInstance);
+    getConnectionSpy.mockResolvedValue(fakeStanzaInstance);
     prepareSpy.mockResolvedValue(null);
 
-    const verifyConnectedIsFalsy = () => {
-      expect(client.connected).toBeFalsy();
-    };
-    const addHandlersSpy = client['addInateEventHandlers'] = jest.fn().mockImplementation(verifyConnectedIsFalsy);
-    const proxyEventsSpy = client['proxyStanzaEvents'] = jest.fn().mockImplementation(verifyConnectedIsFalsy);
-
+    // Setup tracing
+    client['addInateEventHandlers'] = jest.fn().mockImplementation(() => record('addInateEventHandlers'));
+    client['proxyStanzaEvents'] = jest.fn().mockImplementation(() => record('proxyStanzaEvents'));
     const fakeExtension = {
       configureNewStanzaInstance: jest.fn().mockImplementation(() => {
-        expect(client.connected).toBeFalsy();
+        record('configureNewStanzaInstance');
         return Promise.resolve(null);
       }),
-      handleStanzaInstanceChange: jest.fn().mockImplementation(verifyConnectedIsFalsy)
-    }
+      handleStanzaInstanceChange: jest.fn().mockImplementation(() => record('handleStanzaInstanceChange'))
+    };
+    client.on('connected', () => record('connected event'));
 
+    // Setup client state
+    client.connecting = true;
     client['extensions'] = [fakeExtension];
 
-    client.on('connected', () => {
-      expect(true).toBeTruthy();
-    });
-
     await client['makeConnectionAttempt']();
-    expect(client.activeStanzaInstance).toBe(fakeInstance);
-    expect(addHandlersSpy).toHaveBeenCalled();
-    expect(proxyEventsSpy).toHaveBeenCalled();
-    expect(fakeExtension.configureNewStanzaInstance).toHaveBeenCalled();
-    expect(fakeExtension.handleStanzaInstanceChange).toHaveBeenCalled();
-    expect(client.connected).toBeTruthy();
-    expect(client.connecting).toBeFalsy();
+
+    expect(traces).toEqual([
+      { label: 'addInateEventHandlers', connected: false, connecting: true },
+      { label: 'proxyStanzaEvents', connected: false, connecting: true },
+      { label: 'configureNewStanzaInstance', connected: false, connecting: true },
+      { label: 'handleStanzaInstanceChange', connected: false, connecting: true },
+      { label: 'connected event', connected: true, connecting: false },
+    ]);
   });
 
   it('should clean up connection if an extension fails configureNewStanzaInstance', async () => {

--- a/test/unit/client.test.ts
+++ b/test/unit/client.test.ts
@@ -967,6 +967,52 @@ describe('makeConnectionAttempt', () => {
     expect(client.connecting).toBeFalsy();
   });
 
+  /*
+  *  This is to guard an issue where an extension checked the `connected` property but didn't have
+  *  the new stanza instance via `handleStanzaInstanceChange` yet. The extension could be more defensive
+  *  but it seemed like a good idea for the property and the event to be more closely tied.
+  */
+  it('should not set `connected` to `true` until just before emitting the event', async () => {
+    expect.assertions(12);
+    const fakeInstance = {
+      on: jest.fn(),
+      stanzas: {
+        define: jest.fn()
+      }
+    };
+    getConnectionSpy.mockResolvedValue(fakeInstance);
+    prepareSpy.mockResolvedValue(null);
+
+    const verifyConnectedIsFalsy = () => {
+      expect(client.connected).toBeFalsy();
+    };
+    const addHandlersSpy = client['addInateEventHandlers'] = jest.fn().mockImplementation(verifyConnectedIsFalsy);
+    const proxyEventsSpy = client['proxyStanzaEvents'] = jest.fn().mockImplementation(verifyConnectedIsFalsy);
+
+    const fakeExtension = {
+      configureNewStanzaInstance: jest.fn().mockImplementation(() => {
+        expect(client.connected).toBeFalsy();
+        return Promise.resolve(null);
+      }),
+      handleStanzaInstanceChange: jest.fn().mockImplementation(verifyConnectedIsFalsy)
+    }
+
+    client['extensions'] = [fakeExtension];
+
+    client.on('connected', () => {
+      expect(true).toBeTruthy();
+    });
+
+    await client['makeConnectionAttempt']();
+    expect(client.activeStanzaInstance).toBe(fakeInstance);
+    expect(addHandlersSpy).toHaveBeenCalled();
+    expect(proxyEventsSpy).toHaveBeenCalled();
+    expect(fakeExtension.configureNewStanzaInstance).toHaveBeenCalled();
+    expect(fakeExtension.handleStanzaInstanceChange).toHaveBeenCalled();
+    expect(client.connected).toBeTruthy();
+    expect(client.connecting).toBeFalsy();
+  });
+
   it('should clean up connection if an extension fails configureNewStanzaInstance', async () => {
     const disconnectSpy = jest.fn();
     const fakeEmit = jest.fn();


### PR DESCRIPTION
There are more details in the ticket, but I'll reproduce the sequence that seems to be problematic (primarily in `makeConnectionAttempt`):

- The client sets `connected: true`
- The client `await`s extension configuration (currently the WebRTC extension configuring and refreshing ICE servers)
- → At this point a consumer calls `Notifications.makeBulkSubscribeRequest` (or a related method)
  - At this point, the client is `connected`, so it goes ahead and makes the request
  - But the `stanzaInstance` for Notifications hasn’t been updated yet (this will happen next in the `makeConnectionAttempt` sequence), so it uses a channel that make not be valid anymore
- `handleStanzaInstanceChange` is called for each extension
- The client sets up connection monitoring
- The client emits `connected`

I think it's a good idea for `Client.connected` and the `connected` event to be closely tied together, so that's the change in this PR. I acknowledge there's a kind of gap since the extension methods `configureNewStanzaInstanza` and `handleStanzaInstanceChange` won't be able to see `connected: true`. But for now, I think extensions can listen for the `connected` event or use those methods as an implicit signal that the client is connected.